### PR TITLE
Update version of official schema

### DIFF
--- a/el-gml/official-schema-validation.md
+++ b/el-gml/official-schema-validation.md
@@ -10,9 +10,9 @@
 
 * Validate each document against the latest INSPIRE official schema(s), using strict XML schema validation. 
   The official schemas for this data theme are:
-  *  ElevationGridCoverage: https://inspire.ec.europa.eu/schemas/el-cov/4.0/ElevationGridCoverage.xsd
-  *  ElevationVectorElements: https://inspire.ec.europa.eu/schemas/el-vec/4.0/ElevationVectorElements.xsd
-  *  ElevationTIN: https://inspire.ec.europa.eu/schemas/el-tin/4.0/ElevationTin.xsd
+  *  ElevationGridCoverage: https://inspire.ec.europa.eu/schemas/el-cov/5.0/ElevationGridCoverage.xsd
+  *  ElevationVectorElements: https://inspire.ec.europa.eu/schemas/el-vec/5.0/ElevationVectorElements.xsd
+  *  ElevationTIN: https://inspire.ec.europa.eu/schemas/el-tin/5.0/ElevationTin.xsd
 
 **Reference(s)**: 
 


### PR DESCRIPTION
The version of the official schema(s) was updated according to the latest application schema release (https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1).
See the related validator issue for reference: https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1027